### PR TITLE
Exception if ConfirmationMixin not used on Route.

### DIFF
--- a/addon/mixins/confirmation.js
+++ b/addon/mixins/confirmation.js
@@ -1,8 +1,14 @@
 import Ember from 'ember';
 
-const { get, Mixin } = Ember;
+const { get, Mixin, Route } = Ember;
 
 export default Mixin.create({
+  _ensureConfirmationMixinOnRoute: Ember.on('init', function() {
+    if (!(this instanceof Route)) {
+      throw Error('ember-onbeforeunload ConfirmationMixin must be mixed into a Route.');
+    }
+  }),
+
   confirmationMessage(/* model */) {
     return 'Unsaved changed! Are you sure you would like to continue?';
   },

--- a/tests/unit/mixins/confirmation-test.js
+++ b/tests/unit/mixins/confirmation-test.js
@@ -4,9 +4,15 @@ import { module, test } from 'qunit';
 
 module('Unit | Mixin | confirmation');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
-  let ConfirmationObject = Ember.Object.extend(ConfirmationMixin);
-  let subject = ConfirmationObject.create();
+test('allows mixing into a route', function(assert) {
+  let ConfirmationRoute = Ember.Route.extend(ConfirmationMixin);
+  let subject = ConfirmationRoute.create();
   assert.ok(subject);
+});
+
+test('throws an exception when mixing into a plain-ol\' ember object', function(assert) {
+  let ConfirmationObject = Ember.Object.extend(ConfirmationMixin);
+  assert.throws(function() {
+    ConfirmationObject.create();
+  });
 });


### PR DESCRIPTION
I thought I could mix this into my Component, but it relies on the Route lifecycle hooks now that I RTFM. This is a nice warning for consumers who didn't read the manual, like me :smile: