### PR TITLE
Release 0.3.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,6 @@ cache:
   directories:
     - node_modules
 
-env:
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-1.13
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
-
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
@@ -32,4 +20,4 @@ install:
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  - ember try:config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-onbeforeunload",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "An addon to conditionally prompt the user when transitioning between routes or closing the browser.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Bumping up from 0.2.0 because of the new argument checker. If someone, for whatever reason, mixed the ConfirmationMixin into a non-route, it would cause it to break. Will document in release notes.